### PR TITLE
Double precision

### DIFF
--- a/src/cpp/ObjectFileGenerator.cpp
+++ b/src/cpp/ObjectFileGenerator.cpp
@@ -14,6 +14,8 @@
 
 #include "ObjectFileGenerator.h"
 #include <sstream>
+#include <iomanip>
+#include <limits>
 
 void ObjectFileGenerator::generate(Node* tree) {
 	if(forceArrayIdentifier && tree->node_type != NT_TYPEDATA) {
@@ -835,7 +837,10 @@ void ObjectFileGenerator::generate(Node* tree) {
 			file << ")";
 			break;
 
-		case NT_NUMBERLIT: file << tree->node_data.number; break;
+		case NT_NUMBERLIT:
+			file << std::setprecision (std::numeric_limits<double>::digits10 + 1) << tree->node_data.number;
+			break;
+
 		case NT_BOOLLIT: file << (tree->node_data.number ? "1" : "0"); break;
 		case NT_STRINGLIT:
 			file << '"';

--- a/src/wake/stdlib/myobj/std.o
+++ b/src/wake/stdlib/myobj/std.o
@@ -126,7 +126,7 @@ function$ $$A(a, b) {
 		};
 
 		this.`parseNum()` = function() {
-			return$ /^(\-|\+)?([0-9].(\.[0-9]+)?)$$/.test(a) ? Number(a) : null;
+			return$ /^(\-|\+)?([0-9]+(\.[0-9]+)?)$$/.test(a) ? parseFloat(a) : null;
 		};
 
 		this.`charAt(Num)` = function(b) {

--- a/src/wake/test/AutoboxingTest.wk
+++ b/src/wake/test/AutoboxingTest.wk
@@ -226,7 +226,7 @@ every AutoboxingTest is:
 		if Num exists {
 			Asserts.that(Num)Equals($Num);
 		} else {
-			Asserts.fail("Num should have equaled" + $Num.toString() + ", but didn't exist.");
+			Asserts.fail("Num should have equaled " + $Num.toString() + ", but didn't exist.");
 		}
 	}
 

--- a/src/wake/test/PrecisionTest.wk
+++ b/src/wake/test/PrecisionTest.wk
@@ -1,0 +1,20 @@
+import Asserts;
+
+@TestClass
+every PrecisionTest is:
+
+	@Test
+	testDoublePrecisionIsAvailable(Asserts) {
+		Asserts.that(3.211111118482222.toString())Equals("3.211111118482222");
+	}
+
+	@Test
+	testParseNumUsesDoublePrecision(Asserts) {
+		var Text = "3.211111118482222";
+		var Num? = Text.parseNum();
+		if Num exists {
+			Asserts.that(Num)Equals(3.211111118482222);
+		} else {
+			Asserts.fail("couldn't parse double from " + Text);
+		}
+	}


### PR DESCRIPTION
keep parseFloat since it actually parses doubles, see http://stackoverflow.com/questions/21278234/does-parsedouble-exist-in-javascript, new tests for precision which are failing

Still failing tests though

```
Failure in PrecisionTest.testDoublePrecisionIsAvailable(Asserts):
    Failed asserting that 3.211111118482222 is equal to actual 3.21111

Failure in PrecisionTest.testParseNumUsesDoublePrecision(Asserts):
    Failed asserting that 3.21111 is equal to actual 3.211111118482222
```
